### PR TITLE
feat: Open modal with zoom and pan 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Both demos showcase:
 - 🔒 **Privacy-Focused** - No external dependencies, fully offline-capable
 - 📦 **Zero Configuration** - Works out of the box with sensible defaults
 - 🎭 **Smooth UX** - Loading animations and layout shift prevention
+- 🔍 **Fullscreen Zoom & Pan** - Each diagram gets a button to open it in a fullscreen modal with mouse-wheel zoom and drag-to-pan (Escape or click-outside to close)
 - 🦌 **ELK Support** - Optionally works with the `elk` layout ([The Eclipse Layout Kernel](https://eclipse.dev/elk/))
 
 ## Quick Start

--- a/astro-mermaid-integration.js
+++ b/astro-mermaid-integration.js
@@ -485,6 +485,7 @@ async function initMermaid() {
       const { svg } = await mermaid.render(id, diagramDefinition);
       diagram.innerHTML = svg;
       diagram.setAttribute('data-processed', 'true');
+      addModalTrigger(diagram);
       log('Successfully rendered diagram:', id);
     } catch (error) {
       logError('Mermaid rendering error for diagram:', id, error);
@@ -545,6 +546,159 @@ document.addEventListener('astro:after-swap', () => {
   if (hasMermaidDiagrams()) {
     initMermaid();
   }
+});
+
+// ===== Fullscreen modal with zoom + pan =====
+// One shared modal element is reused for every diagram, and all listeners are
+// attached once at script-evaluation time. The script is injected as a module
+// and only runs once per full page load, so nothing accumulates across Astro
+// view transitions (no per-diagram instances, no duplicated listeners).
+
+const modalState = { svg: null, zoom: 1, panX: 0, panY: 0, dragging: false, sx: 0, sy: 0, spx: 0, spy: 0 };
+let modalEl = null;
+let modalCloneSeq = 0;
+
+// Magnify icon shown on each rendered diagram.
+const TRIGGER_ICON = '<svg width="1rem" height="1rem" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M159.997 116a12 12 0 0 1-12 12h-20v20a12 12 0 0 1-24 0v-20h-20a12 12 0 0 1 0-24h20V84a12 12 0 0 1 24 0v20h20a12 12 0 0 1 12 12Zm72.479 116.482a12 12 0 0 1-16.971 0l-40.679-40.679a96.105 96.105 0 1 1 16.972-16.97l40.678 40.678a12 12 0 0 1 0 16.971ZM115.997 188a72 72 0 1 0-72-72 72.081 72.081 0 0 0 72 72Z" fill="currentColor"/></svg>';
+
+// Add a fullscreen trigger button to a rendered diagram. pre.mermaid is
+// position:relative, so the button is absolutely positioned within it.
+function addModalTrigger(pre) {
+  if (pre.querySelector(':scope > .mermaid-modal-btn')) return;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'mermaid-modal-btn';
+  btn.setAttribute('aria-label', 'Open diagram in fullscreen');
+  btn.innerHTML = TRIGGER_ICON;
+  pre.appendChild(btn);
+}
+
+// Rewrite every id (and its url(#id) / href="#id" references) within a cloned
+// SVG so it can coexist in the DOM with the original without duplicate ids.
+function rewriteSvgIds(root) {
+  const prefix = 'mmc-' + (modalCloneSeq++) + '-';
+  const idEls = root.id ? [root] : [];
+  root.querySelectorAll('[id]').forEach(el => idEls.push(el));
+  if (idEls.length === 0) return;
+
+  const map = Object.create(null);
+  idEls.forEach(el => { map[el.id] = prefix + el.id; });
+  idEls.forEach(el => { el.id = map[el.id]; });
+
+  const all = [root];
+  root.querySelectorAll('*').forEach(el => all.push(el));
+  all.forEach(el => {
+    if (!el.attributes) return;
+    Array.from(el.attributes).forEach(attr => {
+      const orig = attr.value;
+      let v = orig.replace(/url\\(#([^)\\s"']+)\\)/g, (m, id) => map[id] ? 'url(#' + map[id] + ')' : m);
+      if ((attr.name === 'href' || attr.name === 'xlink:href') && v.charAt(0) === '#' && map[v.slice(1)]) {
+        v = '#' + map[v.slice(1)];
+      }
+      if (v !== orig) attr.value = v;
+    });
+  });
+}
+
+function applyModalTransform() {
+  if (!modalState.svg) return;
+  const { zoom, panX, panY } = modalState;
+  modalState.svg.style.transform = 'scale(' + zoom + ') translate(' + (panX / zoom) + 'px, ' + (panY / zoom) + 'px)';
+}
+
+function setupPanZoom(wrapper) {
+  const start = (x, y) => {
+    modalState.dragging = true;
+    modalState.sx = x; modalState.sy = y;
+    modalState.spx = modalState.panX; modalState.spy = modalState.panY;
+    wrapper.style.cursor = 'grabbing';
+  };
+  const move = (x, y) => {
+    if (!modalState.dragging) return;
+    modalState.panX = modalState.spx + (x - modalState.sx);
+    modalState.panY = modalState.spy + (y - modalState.sy);
+    applyModalTransform();
+  };
+  const end = () => { modalState.dragging = false; wrapper.style.cursor = 'grab'; };
+
+  wrapper.addEventListener('mousedown', e => start(e.clientX, e.clientY));
+  wrapper.addEventListener('mousemove', e => move(e.clientX, e.clientY));
+  wrapper.addEventListener('mouseup', end);
+  wrapper.addEventListener('mouseleave', end);
+  wrapper.addEventListener('touchstart', e => {
+    if (e.touches.length === 1) start(e.touches[0].clientX, e.touches[0].clientY);
+  }, { passive: true });
+  wrapper.addEventListener('touchmove', e => {
+    if (e.touches.length === 1) { e.preventDefault(); move(e.touches[0].clientX, e.touches[0].clientY); }
+  }, { passive: false });
+  wrapper.addEventListener('touchend', end);
+  wrapper.addEventListener('wheel', e => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? -0.1 : 0.1;
+    modalState.zoom = Math.max(0.2, Math.min(5, modalState.zoom + delta));
+    applyModalTransform();
+  }, { passive: false });
+}
+
+// Lazily create the single shared modal element (and attach its listeners once).
+function ensureModal() {
+  if (modalEl) return modalEl;
+  const overlay = document.createElement('div');
+  overlay.className = 'mermaid-modal-overlay';
+  overlay.innerHTML = '<div class="mermaid-modal-content">' +
+    '<button type="button" class="mermaid-modal-close" aria-label="Close diagram">' +
+    '<svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" fill="currentColor"/></svg>' +
+    '</button>' +
+    '<div class="mermaid-modal-diagram"><div class="diagram-wrapper"></div></div>' +
+    '</div>';
+  document.body.appendChild(overlay);
+  modalEl = overlay;
+
+  overlay.querySelector('.mermaid-modal-close').addEventListener('click', closeModal);
+  overlay.addEventListener('click', e => { if (e.target === overlay) closeModal(); });
+  setupPanZoom(overlay.querySelector('.diagram-wrapper'));
+  return overlay;
+}
+
+function openModal(pre) {
+  const src = pre.querySelector('svg');
+  if (!src) return;
+  const overlay = ensureModal();
+  const wrapper = overlay.querySelector('.diagram-wrapper');
+
+  modalState.zoom = 1; modalState.panX = 0; modalState.panY = 0; modalState.dragging = false;
+  const clone = src.cloneNode(true);
+  rewriteSvgIds(clone);
+  clone.style.transformOrigin = 'center center';
+  clone.style.transform = 'scale(1) translate(0, 0)';
+  modalState.svg = clone;
+
+  wrapper.innerHTML = '';
+  wrapper.appendChild(clone);
+  overlay.classList.add('show');
+  document.body.style.overflow = 'hidden';
+}
+
+function closeModal() {
+  if (!modalEl) return;
+  modalEl.classList.remove('show');
+  document.body.style.overflow = '';
+  const wrapper = modalEl.querySelector('.diagram-wrapper');
+  if (wrapper) wrapper.innerHTML = '';
+  modalState.svg = null;
+}
+
+// Open the modal via event delegation so a single listener covers every
+// current and future diagram (no per-diagram binding).
+document.addEventListener('click', e => {
+  const btn = e.target.closest && e.target.closest('.mermaid-modal-btn');
+  if (!btn) return;
+  const pre = btn.closest('pre.mermaid');
+  if (pre) openModal(pre);
+});
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape' && modalEl && modalEl.classList.contains('show')) closeModal();
 });
 `;
 
@@ -628,6 +782,166 @@ document.addEventListener('astro:after-swap', () => {
             [data-theme="light"] pre.mermaid[data-processed] {
               background-color: rgba(0, 0, 0, 0.02);
               border-radius: 0.5rem;
+            }
+
+            /* ===== Fullscreen modal (zoom + pan) ===== */
+            /* The modal matches the host page's theme by reading the page's own
+               CSS variables: Starlight's --sl-color-* first, then common custom
+               theme vars (--bg-primary / --text-primary / --border / --shadow).
+               When neither exists, the OS-preference fallbacks below apply. The
+               mapping is declared on the consuming elements (not :root) so that
+               page themes toggled on <body> resolve to the right value. */
+            :root {
+              --mm-bg-fallback: #ffffff;
+              --mm-fg-fallback: #1f2937;
+              --mm-border-fallback: rgba(0, 0, 0, 0.12);
+              --mm-shadow-fallback: rgba(0, 0, 0, 0.25);
+            }
+            @media (prefers-color-scheme: dark) {
+              :root {
+                --mm-bg-fallback: #1e1e1e;
+                --mm-fg-fallback: #e5e7eb;
+                --mm-border-fallback: rgba(255, 255, 255, 0.15);
+                --mm-shadow-fallback: rgba(0, 0, 0, 0.6);
+              }
+            }
+            .mermaid-modal-overlay,
+            pre.mermaid > .mermaid-modal-btn {
+              --mm-bg: var(--sl-color-bg, var(--bg-primary, var(--mm-bg-fallback)));
+              --mm-fg: var(--sl-color-text, var(--text-primary, var(--mm-fg-fallback)));
+              --mm-border: var(--sl-color-gray-5, var(--border, var(--mm-border-fallback)));
+              --mm-shadow: var(--sl-color-shadow, var(--shadow, var(--mm-shadow-fallback)));
+            }
+
+            pre.mermaid > .mermaid-modal-btn {
+              position: absolute;
+              top: 0.5rem;
+              right: 0.5rem;
+              z-index: 5;
+              display: inline-flex;
+              align-items: center;
+              justify-content: center;
+              padding: 0.3rem;
+              border-radius: 0.5rem;
+              cursor: pointer;
+              color: var(--mm-fg);
+              background: var(--mm-bg);
+              border: 1px solid var(--mm-border);
+              box-shadow: 0 1px 2px var(--mm-shadow);
+              opacity: 0;
+              transition: opacity 0.2s ease, transform 0.2s ease, background 0.2s ease;
+            }
+            pre.mermaid:hover > .mermaid-modal-btn,
+            pre.mermaid > .mermaid-modal-btn:focus-visible {
+              opacity: 0.85;
+            }
+            pre.mermaid > .mermaid-modal-btn:hover {
+              opacity: 1;
+              transform: translateY(-1px);
+            }
+            /* Always show the trigger on touch devices (no hover) */
+            @media (hover: none) {
+              pre.mermaid > .mermaid-modal-btn { opacity: 0.7; }
+            }
+
+            .mermaid-modal-overlay {
+              position: fixed;
+              inset: 0;
+              z-index: 99999;
+              display: none;
+              align-items: center;
+              justify-content: center;
+              padding: 2rem;
+              background: rgba(0, 0, 0, 0.6);
+              opacity: 0;
+              transition: opacity 0.25s ease;
+            }
+            .mermaid-modal-overlay.show {
+              display: flex;
+              opacity: 1;
+            }
+
+            .mermaid-modal-content {
+              position: relative;
+              display: flex;
+              flex-direction: column;
+              width: min(1200px, 92vw);
+              height: min(85vh, 900px);
+              background: var(--mm-bg);
+              color: var(--mm-fg);
+              border: 1px solid var(--mm-border);
+              border-radius: 0.75rem;
+              box-shadow: 0 8px 32px var(--mm-shadow);
+              transform: scale(0.96);
+              transition: transform 0.25s ease;
+            }
+            .mermaid-modal-overlay.show .mermaid-modal-content {
+              transform: scale(1);
+            }
+
+            .mermaid-modal-close {
+              position: absolute;
+              top: 0.75rem;
+              right: 0.75rem;
+              z-index: 2;
+              display: inline-flex;
+              align-items: center;
+              justify-content: center;
+              padding: 0.25rem;
+              cursor: pointer;
+              color: var(--mm-fg);
+              background: var(--mm-bg);
+              border: 1px solid var(--mm-border);
+              border-radius: 0.5rem;
+              box-shadow: 0 1px 2px var(--mm-shadow);
+              transition: transform 0.2s ease;
+            }
+            .mermaid-modal-close:hover {
+              transform: translateY(-1px);
+            }
+
+            .mermaid-modal-diagram {
+              flex: 1;
+              min-height: 0;
+              padding: 1.5rem;
+            }
+            .diagram-wrapper {
+              width: 100%;
+              height: 100%;
+              overflow: hidden;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              cursor: grab;
+              user-select: none;
+              touch-action: none;
+            }
+            .diagram-wrapper:active {
+              cursor: grabbing;
+            }
+            .diagram-wrapper svg {
+              max-width: 100%;
+              max-height: 100%;
+              width: auto;
+              height: auto;
+              transform-origin: center center;
+            }
+
+            @media (prefers-reduced-motion: reduce) {
+              .mermaid-modal-overlay,
+              .mermaid-modal-content,
+              .mermaid-modal-close,
+              pre.mermaid > .mermaid-modal-btn {
+                transition: none;
+              }
+            }
+            @media (max-width: 768px) {
+              .mermaid-modal-overlay { padding: 1rem; }
+              .mermaid-modal-content {
+                width: 100%;
+                height: 100%;
+                border-radius: 0;
+              }
             }
           \`;
           document.head.appendChild(style);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -445,4 +445,86 @@ describe('astroMermaid Integration', () => {
       expect(clientScript).toContain('mermaid.render');
     });
   });
+
+  describe('fullscreen modal (zoom + pan)', () => {
+    async function setup(options = {}) {
+      const integration = astroMermaid(options);
+      const injectScriptMock = vi.fn();
+      await integration.hooks['astro:config:setup']({
+        config: { markdown: {}, root: new URL('file:///test/') },
+        updateConfig: vi.fn(),
+        addWatchFile: vi.fn(),
+        injectScript: injectScriptMock,
+        logger: { info: vi.fn(), warn: vi.fn() },
+        command: 'build'
+      });
+      return {
+        js: injectScriptMock.mock.calls[0][1],
+        css: injectScriptMock.mock.calls[1][1],
+        callCount: injectScriptMock.mock.calls.length
+      };
+    }
+
+    it('should still inject exactly two scripts (JS + CSS)', async () => {
+      const { callCount } = await setup();
+      expect(callCount).toBe(2);
+    });
+
+    it('should add a trigger button to each rendered diagram', async () => {
+      const { js } = await setup();
+      expect(js).toContain('addModalTrigger');
+      expect(js).toContain('mermaid-modal-btn');
+    });
+
+    it('should reuse a single shared modal element', async () => {
+      const { js } = await setup();
+      expect(js).toContain('mermaid-modal-overlay');
+      // ensureModal guards against creating more than one modal
+      expect(js).toContain('if (modalEl) return modalEl');
+    });
+
+    it('should open diagrams via event delegation rather than per-diagram instances', async () => {
+      const { js } = await setup();
+      expect(js).toContain("e.target.closest('.mermaid-modal-btn')");
+      // Must NOT recreate per-diagram modal instances on every page load
+      expect(js).not.toContain('new MermaidModal');
+    });
+
+    it('should rewrite cloned SVG ids to avoid duplicate ids in the DOM', async () => {
+      const { js } = await setup();
+      expect(js).toContain('cloneNode(true)');
+      expect(js).toContain('rewriteSvgIds');
+      // url(#id) references must be rewritten alongside the ids
+      expect(js).toContain('url(#');
+    });
+
+    it('should support zoom (wheel) and pan (drag) interactions', async () => {
+      const { js } = await setup();
+      expect(js).toContain("addEventListener('wheel'");
+      expect(js).toContain('applyModalTransform');
+    });
+
+    it('should close on Escape and restore body scroll', async () => {
+      const { js } = await setup();
+      expect(js).toContain("e.key === 'Escape'");
+      expect(js).toContain("document.body.style.overflow = ''");
+    });
+
+    it('should not couple the modal to Starlight-specific selectors', async () => {
+      const { js } = await setup();
+      // The original PR hid Starlight sidebars by class — that coupling is gone
+      expect(js).not.toContain('starlight__sidebar');
+      expect(js).not.toContain('right-sidebar-container');
+    });
+
+    it('should ship portable modal CSS with Starlight-var fallbacks', async () => {
+      const { css } = await setup();
+      expect(css).toContain('.mermaid-modal-overlay');
+      expect(css).toContain('.diagram-wrapper');
+      // Colors follow the host page's theme vars (Starlight, then common custom
+      // theme vars), falling back to an OS-preference default — never hardcoded.
+      expect(css).toContain('var(--sl-color-bg, var(--bg-primary, var(--mm-bg-fallback)))');
+      expect(css).toContain('@media (prefers-color-scheme: dark)');
+    });
+  });
 });

--- a/test/modal-dom.test.js
+++ b/test/modal-dom.test.js
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll } from 'vitest';
+import astroMermaid from '../astro-mermaid-integration.js';
+
+// Pull the real client-side script the integration injects, then load it into
+// jsdom so we can exercise the modal end-to-end (click -> open -> SVG clone with
+// rewritten ids). This verifies the actual emitted code, not a copy of it.
+async function getClientScript() {
+  const integ = astroMermaid();
+  let js;
+  await integ.hooks['astro:config:setup']({
+    config: { markdown: {}, root: new URL('file:///t/') },
+    updateConfig() {},
+    addWatchFile() {},
+    injectScript: (stage, code) => { if (js === undefined) js = code; },
+    logger: { info() {}, warn() {} },
+    command: 'build'
+  });
+  return js;
+}
+
+function makeDiagram() {
+  // A pre.mermaid containing a rendered SVG with internal ids + url(#) refs,
+  // plus the trigger button the integration would have added.
+  const pre = document.createElement('pre');
+  pre.className = 'mermaid';
+  pre.setAttribute('data-processed', 'true');
+  pre.innerHTML = `
+    <svg id="diagram-root" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <marker id="arrowhead"><path d="M0 0L10 5L0 10z"/></marker>
+        <linearGradient id="grad"><stop offset="0"/></linearGradient>
+      </defs>
+      <path d="M0 0L100 100" marker-end="url(#arrowhead)"/>
+      <rect fill="url(#grad)" width="10" height="10"/>
+    </svg>
+    <button type="button" class="mermaid-modal-btn" aria-label="Open diagram in fullscreen"></button>
+  `;
+  document.body.appendChild(pre);
+  return pre;
+}
+
+describe('modal DOM behaviour', () => {
+  beforeAll(async () => {
+    const js = await getClientScript();
+    // The injected script has no static imports/exports, so it runs as a
+    // classic script. Indirect eval executes the top-level code in the jsdom
+    // global scope: it defines the modal helpers and attaches the single
+    // delegated click + keydown listeners to `document`.
+    (0, eval)(js);
+  });
+
+  it('opens a single shared modal when the trigger is clicked', () => {
+    const pre = makeDiagram();
+    expect(document.querySelector('.mermaid-modal-overlay')).toBeNull();
+
+    pre.querySelector('.mermaid-modal-btn').dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    const overlay = document.querySelector('.mermaid-modal-overlay');
+    expect(overlay).not.toBeNull();
+    expect(overlay.classList.contains('show')).toBe(true);
+    expect(document.querySelector('.diagram-wrapper svg')).not.toBeNull();
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('reuses the same modal element for a second diagram (no accumulation)', () => {
+    const before = document.querySelectorAll('.mermaid-modal-overlay').length;
+    const pre = makeDiagram();
+    pre.querySelector('.mermaid-modal-btn').dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(document.querySelectorAll('.mermaid-modal-overlay').length).toBe(before);
+  });
+
+  it('rewrites cloned SVG ids and url(#) references to avoid duplicate ids', () => {
+    const pre = makeDiagram();
+    pre.querySelector('.mermaid-modal-btn').dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    const clone = document.querySelector('.diagram-wrapper svg');
+    // The clone's ids must differ from the originals still in the page.
+    expect(clone.id).not.toBe('diagram-root');
+    expect(clone.querySelector('#arrowhead')).toBeNull();
+    expect(clone.querySelector('#grad')).toBeNull();
+
+    const marker = clone.querySelector('marker');
+    const path = clone.querySelector('path[marker-end]');
+    const rect = clone.querySelector('rect');
+    // The reference must point at the rewritten id, not the stale original.
+    expect(path.getAttribute('marker-end')).toBe(`url(#${marker.id})`);
+    const gradId = clone.querySelector('linearGradient').id;
+    expect(rect.getAttribute('fill')).toBe(`url(#${gradId})`);
+
+    // The original diagram in the page is untouched.
+    expect(document.querySelector('pre.mermaid svg#diagram-root')).not.toBeNull();
+  });
+
+  it('closes on Escape and restores body scroll', () => {
+    const pre = makeDiagram();
+    pre.querySelector('.mermaid-modal-btn').dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(document.querySelector('.mermaid-modal-overlay').classList.contains('show')).toBe(true);
+
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.querySelector('.mermaid-modal-overlay').classList.contains('show')).toBe(false);
+    expect(document.body.style.overflow).toBe('');
+  });
+});


### PR DESCRIPTION
## Changes Included:
- **Modal Integration**: Added the ability to open diagrams inside a modal with zoom and pan capabilities
- **rehypeMermaid Support**: Fixed color issues and extended support to work with `rehypeMermaid `
- **UI/UX Improvements**: Adjusted the modal close button, expanded diagram wrapper to full container height, centered content, and optimized scroll/pan performance for smoother interactions.

#### Commits:
- `c99a01e`: Adjusted modal close button, increased diagram wrapper height to full container, center content and improved scroll / pan performance
- `f237c99`: Fixed colors and added support to rehypeMermaid (works also on .md files)
- `649524d`: Added opening diagram inside a modal and zoom / pan integration

### Testing
- Verified modal opening and closing functionality
- Tested zoom/pan interactions across different diagram types
- Confirmed compatibility with both `.mdx` and `.md` files
- Checked performance improvements in scroll/pan operations

---

### Images

<img width="1856" height="871" alt="Captura de pantalla_20251025_154726" src="https://github.com/user-attachments/assets/cfab0451-1ca1-42c9-bcd3-bf18ac9a2c38" />

<img width="1856" height="871" alt="Captura de pantalla_20251025_154632" src="https://github.com/user-attachments/assets/72552746-66fa-4ff0-aa95-8b837cb8119b" />
