### PR TITLE
Chore: support Astro 6.x and above in peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "peerDependencies": {
         "@mermaid-js/layout-elk": "^0.2.0",
-        "astro": "^4.0.0 || ^5.0.0",
+        "astro": ">=4",
         "mermaid": "^10.0.0 || ^11.0.0"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@mermaid-js/layout-elk": "^0.2.0",
-    "astro": "^4.0.0 || ^5.0.0",
+    "astro": ">=4",
     "mermaid": "^10.0.0 || ^11.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
### What does this PR do?
This PR updates the `peerDependencies` for `astro` from the restrictive `"^4.0.0 || ^5.0.0"` to `>=4`.

### Why is this necessary?
With the release of Astro 6.x, users attempting to install `astro-mermaid` alongside the new stable version are encountering `ERESOLVE` conflicting peer dependency errors during `npm install`.

By changing the dependency range to `>=4`, `astro-mermaid` will seamlessly support Astro 4, 5, 6, and future major releases without requiring frequent updates to the `package.json` file for every new Astro major version.

