### PR TITLE
fix!: Claude/fix security issues

### DIFF
--- a/astro-demo/netlify.toml
+++ b/astro-demo/netlify.toml
@@ -4,6 +4,7 @@
 
 [build.environment]
   NODE_VERSION = "22"
+  NPM_FLAGS = "--legacy-peer-deps"
 
 [[headers]]
   for = "/*"

--- a/astro-mermaid-integration.d.ts
+++ b/astro-mermaid-integration.d.ts
@@ -5,11 +5,19 @@ export interface IconPack {
    * Name of the icon pack
    */
   name: string;
-  
+
   /**
-   * Function that returns a promise resolving to the icon pack data
+   * URL to the icon pack JSON file (preferred, safe serialization).
+   * @example 'https://unpkg.com/@iconify-json/logos@1/icons.json'
    */
-  loader: () => Promise<any>;
+  url?: string;
+
+  /**
+   * Legacy: loader function whose source is inspected for a fetch() URL.
+   * Prefer using the `url` property instead for safer serialization.
+   * @deprecated Use `url` instead.
+   */
+  loader?: () => Promise<any>;
 }
 
 export interface AstroMermaidOptions {

--- a/astro-mermaid-integration.js
+++ b/astro-mermaid-integration.js
@@ -16,6 +16,36 @@ function escapeHtml(text) {
 }
 
 /**
+ * Sanitize a JSON string for safe embedding inside a <script> tag.
+ * Prevents premature script termination via </script> or <!-- sequences.
+ */
+function sanitizeJsonForScript(jsonStr) {
+  return jsonStr
+    .replace(/<\//g, '<\\/')
+    .replace(/<!--/g, '<\\!--');
+}
+
+/**
+ * Validate that mermaidConfig is a plain object (not an array, null, etc.)
+ * and does not contain __proto__ or constructor keys to prevent prototype pollution.
+ */
+function validateConfig(obj, path = 'mermaidConfig') {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    return;
+  }
+  const dangerous = ['__proto__', 'constructor', 'prototype'];
+  // Use getOwnPropertyNames to catch __proto__ which Object.keys skips
+  for (const key of Object.getOwnPropertyNames(obj)) {
+    if (dangerous.includes(key)) {
+      throw new Error(`astro-mermaid: "${key}" is not allowed in ${path}`);
+    }
+    if (typeof obj[key] === 'object' && obj[key] !== null) {
+      validateConfig(obj[key], `${path}.${key}`);
+    }
+  }
+}
+
+/**
  * Remark plugin to transform mermaid code blocks at the markdown level
  */
 function remarkMermaidPlugin(options = {}) {
@@ -52,6 +82,27 @@ function remarkMermaidPlugin(options = {}) {
 }
 
 /**
+ * Escape a string for safe use inside an HTML attribute value.
+ */
+function escapeAttribute(value) {
+  return String(value).replace(/[&<>"']/g, char => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  })[char]);
+}
+
+/**
+ * Allowlist of safe HTML tag names that may appear inside mermaid HAST content.
+ */
+const ALLOWED_TAG_NAMES = new Set([
+  'b', 'i', 'u', 'em', 'strong', 'br', 'hr', 'sub', 'sup', 'span', 'div',
+  'code', 'pre', 'img', 'a', 'p', 'ul', 'ol', 'li'
+]);
+
+/**
  * Helper function to serialize HAST nodes back to HTML text
  * This preserves HTML tags within the mermaid content
  */
@@ -62,19 +113,26 @@ function serializeHastChildren(children) {
     if (child.type === 'text') {
       result += child.value;
     } else if (child.type === 'element') {
-      // Reconstruct the HTML tag
+      // Reconstruct the HTML tag — only allow safe tag names
       const tagName = child.tagName;
+      if (!ALLOWED_TAG_NAMES.has(tagName)) {
+        // Skip disallowed tags, but still serialize their text children
+        if (child.children && child.children.length > 0) {
+          result += serializeHastChildren(child.children);
+        }
+        continue;
+      }
       const selfClosing = ['br', 'hr', 'img', 'input', 'meta', 'link'].includes(tagName);
 
       result += `<${tagName}`;
 
-      // Add attributes if any
+      // Add attributes if any — escape all attribute values
       if (child.properties) {
         for (const [key, value] of Object.entries(child.properties)) {
           if (key !== 'className') {
-            result += ` ${key}="${value}"`;
+            result += ` ${key}="${escapeAttribute(value)}"`;
           } else if (Array.isArray(value)) {
-            result += ` class="${value.join(' ')}"`;
+            result += ` class="${escapeAttribute(value.join(' '))}"`;
           }
         }
       }
@@ -176,6 +234,9 @@ export default function astroMermaid(options = {}) {
     enableLog = true
   } = options;
 
+  // Validate mermaidConfig to prevent prototype pollution
+  validateConfig(mermaidConfig);
+
   return {
     name: 'astro-mermaid',
     hooks: {
@@ -213,11 +274,37 @@ export default function astroMermaid(options = {}) {
           }
         });
 
-        // Serialize icon packs for client-side use
-        const iconPacksConfig = iconPacks.map(pack => ({
-          name: pack.name,
-          loader: pack.loader.toString()
-        }));
+        // Validate and serialize icon packs for client-side use.
+        // Only the pack name and a JSON URL string are forwarded to the
+        // client — we never serialize arbitrary function bodies.
+        const iconPacksConfig = iconPacks.map(pack => {
+          if (typeof pack.name !== 'string' || !pack.name) {
+            throw new Error('astro-mermaid: each iconPack must have a non-empty "name" string');
+          }
+          if (typeof pack.url === 'string') {
+            // Preferred: explicit URL
+            return { name: pack.name, url: pack.url };
+          }
+          if (typeof pack.loader === 'function') {
+            // Legacy: extract URL from loader().toString() if it contains a
+            // fetch('...') call, otherwise warn and skip.
+            const src = pack.loader.toString();
+            const urlMatch = src.match(/fetch\s*\(\s*['"]([^'"]+)['"]\s*\)/);
+            if (urlMatch) {
+              return { name: pack.name, url: urlMatch[1] };
+            }
+            logger.warn(
+              `astro-mermaid: iconPack "${pack.name}" uses a loader function ` +
+              `that could not be safely serialized. Please provide a "url" ` +
+              `property instead. This pack will be skipped.`
+            );
+            return null;
+          }
+          throw new Error(
+            `astro-mermaid: iconPack "${pack.name}" must have a "url" string ` +
+            `or a "loader" function`
+          );
+        }).filter(Boolean);
 
         // Inject client-side mermaid script with conditional loading
         const mermaidScriptContent = `
@@ -240,13 +327,13 @@ async function loadMermaid() {
   log('Loading mermaid.js...');
 
   mermaidPromise = import('mermaid').then(async ({ default: mermaid }) => {
-    // Register icon packs if provided
-    const iconPacks = ${JSON.stringify(iconPacksConfig)};
+    // Register icon packs if provided — uses safe fetch(url) instead of eval
+    const iconPacks = ${sanitizeJsonForScript(JSON.stringify(iconPacksConfig))};
     if (iconPacks && iconPacks.length > 0) {
       log('Registering', iconPacks.length, 'icon packs');
       const packs = iconPacks.map(pack => ({
         name: pack.name,
-        loader: new Function('return ' + pack.loader)()
+        loader: () => fetch(pack.url).then(res => res.json())
       }));
       await mermaid.registerIconPacks(packs);
     }
@@ -272,11 +359,11 @@ if (elkModule?.default) {
 }
 
 // Mermaid configuration
-const defaultConfig = ${JSON.stringify({
+const defaultConfig = ${sanitizeJsonForScript(JSON.stringify({
   startOnLoad: false,
   theme: theme,
   ...mermaidConfig
-})};
+}))};
 
 // Theme mapping for auto-theme switching
 const themeMap = {
@@ -350,10 +437,17 @@ async function initMermaid() {
       log('Successfully rendered diagram:', id);
     } catch (error) {
       logError('Mermaid rendering error for diagram:', id, error);
-      diagram.innerHTML = \`<div style="color: red; padding: 1rem; border: 1px solid red; border-radius: 0.5rem;">
-        <strong>Error rendering diagram:</strong><br/>
-        \${error.message || 'Unknown error'}
-      </div>\`;
+      // Build error UI safely — use textContent to prevent XSS via error messages
+      const errorDiv = document.createElement('div');
+      errorDiv.style.cssText = 'color: red; padding: 1rem; border: 1px solid red; border-radius: 0.5rem;';
+      const strong = document.createElement('strong');
+      strong.textContent = 'Error rendering diagram:';
+      const msg = document.createElement('span');
+      msg.textContent = ' ' + (error.message || 'Unknown error');
+      errorDiv.appendChild(strong);
+      errorDiv.appendChild(msg);
+      diagram.textContent = '';
+      diagram.appendChild(errorDiv);
       diagram.setAttribute('data-processed', 'true');
     }
   }

--- a/starlight-demo/netlify.toml
+++ b/starlight-demo/netlify.toml
@@ -4,6 +4,7 @@
 
 [build.environment]
   NODE_VERSION = "22"
+  NPM_FLAGS = "--legacy-peer-deps"
 
 [[headers]]
   for = "/*"

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -144,6 +144,163 @@ describe('astroMermaid Integration', () => {
     });
   });
 
+  describe('security', () => {
+    it('should not use new Function or eval in client script', async () => {
+      const integration = astroMermaid({
+        iconPacks: [
+          { name: 'test', url: 'https://example.com/icons.json' }
+        ]
+      });
+
+      const mockConfig = {
+        markdown: {},
+        root: new URL('file:///test/')
+      };
+
+      const injectScriptMock = vi.fn();
+
+      await integration.hooks['astro:config:setup']({
+        config: mockConfig,
+        updateConfig: vi.fn(),
+        addWatchFile: vi.fn(),
+        injectScript: injectScriptMock,
+        logger: { info: vi.fn(), warn: vi.fn() },
+        command: 'build'
+      });
+
+      const clientScript = injectScriptMock.mock.calls[0][1];
+      expect(clientScript).not.toContain('new Function');
+      expect(clientScript).not.toContain('eval(');
+    });
+
+    it('should not inject error.message via innerHTML in client script', async () => {
+      const integration = astroMermaid();
+      const mockConfig = {
+        markdown: {},
+        root: new URL('file:///test/')
+      };
+
+      const injectScriptMock = vi.fn();
+
+      await integration.hooks['astro:config:setup']({
+        config: mockConfig,
+        updateConfig: vi.fn(),
+        addWatchFile: vi.fn(),
+        injectScript: injectScriptMock,
+        logger: { info: vi.fn(), warn: vi.fn() },
+        command: 'build'
+      });
+
+      const clientScript = injectScriptMock.mock.calls[0][1];
+      // The error handler should use textContent, not innerHTML with interpolation
+      expect(clientScript).toContain('textContent');
+      expect(clientScript).not.toMatch(/innerHTML\s*=\s*`[^`]*error\.message/);
+    });
+
+    it('should reject mermaidConfig with __proto__ key', () => {
+      // Use JSON.parse to create an object that actually has __proto__ as own property
+      // (object literals set the prototype instead of creating a key)
+      const malicious = JSON.parse('{"__proto__": {"polluted": true}}');
+      expect(() => {
+        astroMermaid({ mermaidConfig: malicious });
+      }).toThrow('"__proto__" is not allowed');
+    });
+
+    it('should reject mermaidConfig with constructor key', () => {
+      expect(() => {
+        astroMermaid({ mermaidConfig: { constructor: {} } });
+      }).toThrow('"constructor" is not allowed');
+    });
+
+    it('should reject mermaidConfig with nested prototype key', () => {
+      expect(() => {
+        astroMermaid({ mermaidConfig: { flowchart: { prototype: {} } } });
+      }).toThrow('"prototype" is not allowed');
+    });
+
+    it('should accept iconPacks with url property', async () => {
+      const integration = astroMermaid({
+        iconPacks: [
+          { name: 'logos', url: 'https://unpkg.com/@iconify-json/logos@1/icons.json' }
+        ]
+      });
+
+      const mockConfig = {
+        markdown: {},
+        root: new URL('file:///test/')
+      };
+
+      const injectScriptMock = vi.fn();
+
+      await integration.hooks['astro:config:setup']({
+        config: mockConfig,
+        updateConfig: vi.fn(),
+        addWatchFile: vi.fn(),
+        injectScript: injectScriptMock,
+        logger: { info: vi.fn(), warn: vi.fn() },
+        command: 'build'
+      });
+
+      const clientScript = injectScriptMock.mock.calls[0][1];
+      expect(clientScript).toContain('https://unpkg.com/@iconify-json/logos@1/icons.json');
+      expect(clientScript).toContain('fetch(pack.url)');
+    });
+
+    it('should extract URL from legacy loader function', async () => {
+      const integration = astroMermaid({
+        iconPacks: [
+          { name: 'test', loader: () => fetch('https://example.com/icons.json').then(res => res.json()) }
+        ]
+      });
+
+      const mockConfig = {
+        markdown: {},
+        root: new URL('file:///test/')
+      };
+
+      const injectScriptMock = vi.fn();
+
+      await integration.hooks['astro:config:setup']({
+        config: mockConfig,
+        updateConfig: vi.fn(),
+        addWatchFile: vi.fn(),
+        injectScript: injectScriptMock,
+        logger: { info: vi.fn(), warn: vi.fn() },
+        command: 'build'
+      });
+
+      const clientScript = injectScriptMock.mock.calls[0][1];
+      expect(clientScript).toContain('https://example.com/icons.json');
+    });
+
+    it('should sanitize JSON to prevent script injection', async () => {
+      const integration = astroMermaid({
+        mermaidConfig: { note: '</script><script>alert(1)</script>' }
+      });
+
+      const mockConfig = {
+        markdown: {},
+        root: new URL('file:///test/')
+      };
+
+      const injectScriptMock = vi.fn();
+
+      await integration.hooks['astro:config:setup']({
+        config: mockConfig,
+        updateConfig: vi.fn(),
+        addWatchFile: vi.fn(),
+        injectScript: injectScriptMock,
+        logger: { info: vi.fn(), warn: vi.fn() },
+        command: 'build'
+      });
+
+      const clientScript = injectScriptMock.mock.calls[0][1];
+      // Should not contain a literal </script> — it should be escaped as <\/script>
+      expect(clientScript).not.toContain('</script>');
+      expect(clientScript).toContain('<\\/script>');
+    });
+  });
+
   describe('client-side rendering', () => {
     it('should handle escaped HTML content in client-side code', async () => {
       // Document the requirement for client-side handling

--- a/test/rehype-plugin.test.js
+++ b/test/rehype-plugin.test.js
@@ -18,6 +18,21 @@ function escapeHtml(text) {
   return text.replace(/[&<>"']/g, char => htmlEntities[char]);
 }
 
+function escapeAttribute(value) {
+  return String(value).replace(/[&<>"']/g, char => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  })[char]);
+}
+
+const ALLOWED_TAG_NAMES = new Set([
+  'b', 'i', 'u', 'em', 'strong', 'br', 'hr', 'sub', 'sup', 'span', 'div',
+  'code', 'pre', 'img', 'a', 'p', 'ul', 'ol', 'li'
+]);
+
 function serializeHastChildren(children) {
   let result = '';
 
@@ -26,6 +41,12 @@ function serializeHastChildren(children) {
       result += child.value;
     } else if (child.type === 'element') {
       const tagName = child.tagName;
+      if (!ALLOWED_TAG_NAMES.has(tagName)) {
+        if (child.children && child.children.length > 0) {
+          result += serializeHastChildren(child.children);
+        }
+        continue;
+      }
       const selfClosing = ['br', 'hr', 'img', 'input', 'meta', 'link'].includes(tagName);
 
       result += `<${tagName}`;
@@ -33,9 +54,9 @@ function serializeHastChildren(children) {
       if (child.properties) {
         for (const [key, value] of Object.entries(child.properties)) {
           if (key !== 'className') {
-            result += ` ${key}="${value}"`;
+            result += ` ${key}="${escapeAttribute(value)}"`;
           } else if (Array.isArray(value)) {
-            result += ` class="${value.join(' ')}"`;
+            result += ` class="${escapeAttribute(value.join(' '))}"`;
           }
         }
       }


### PR DESCRIPTION
## Summary
- Fix XSS in error handler: use textContent/createElement instead of innerHTML with unescaped error.message
- Remove `new Function()` (eval equivalent) for icon pack loaders: serialize URL strings instead of function bodies
- Escape attribute values in serializeHastChildren to prevent attribute injection
- Add tag name allowlist in serializeHastChildren to block arbitrary HTML elements
- Sanitize JSON.stringify output for inline scripts to prevent premature `</script>` termination
- Add prototype pollution validation for mermaidConfig (rejects `__proto__`, `constructor`, `prototype` keys)
- Update TypeScript definitions with new `url` property on IconPack
- Add comprehensive security test suite

## Test plan
- [ ] Verify existing mermaid diagrams still render correctly
- [ ] Verify icon packs still load in architecture diagrams
- [ ] Run `npm test` — new security tests should pass
- [ ] Check Netlify deploy previews for both demos
