### PR TITLE
ci: configure npm trusted publishing oidc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
@@ -32,6 +31,4 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ This project uses **semantic-release** with **Conventional Commits**. All commit
 1. Push/merge to `main` triggers `.github/workflows/release.yml`
 2. `semantic-release` analyzes commits since last release
 3. If a releasable commit is found: bumps version, publishes to npm, creates GitHub release and tag
-4. Required secrets: `NPM_TOKEN` (npm publish), `GITHUB_TOKEN` (auto-provided)
+4. Authentication uses **npm Trusted Publishing (OIDC)**, meaning no manual `NPM_TOKEN` secret is required in repository settings.
 
 ## Development Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ graph TD
 Publishing is fully automated via semantic-release:
 - Merging a `feat:` or `fix:` commit to `main` triggers npm publish
 - GitHub Releases and git tags are created automatically
-- NPM_TOKEN secret must be configured in GitHub repository settings
+- Authentication is handled via **npm Trusted Publishers (OIDC)** (no `NPM_TOKEN` secret required)
 
 The integration provides a zero-configuration solution for beautiful mermaid diagrams in Astro projects.
 


### PR DESCRIPTION
This PR configures the release workflow to use npm Trusted Publishing via OIDC, resolving conflicts caused by setting registry-url in setup-node and empty/invalid static token variables. It also updates AGENTS.md and CLAUDE.md to document the change.