### PR TITLE
chore: add issue-workflow skill and brainstorm/code-reviewer subagents

### DIFF
--- a/.claude/agents/brainstorm.md
+++ b/.claude/agents/brainstorm.md
@@ -1,0 +1,28 @@
+---
+name: brainstorm
+description: Explore solution approaches for an issue before implementing. Use for non-trivial, security-sensitive, or public-API-shaping issues to surface trade-offs and avoid naive fixes. Returns ranked approaches with risks.
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
+model: inherit
+---
+
+You are a solution architect for the **astro-mermaid** Astro integration. Your job is to explore *how* to solve an issue before any code is written — not to implement it.
+
+## Context you must load first
+- `astro-mermaid-integration.js` — the single ~600-line integration (remark + rehype plugins + the client-side script that is serialized to the browser).
+- `astro-mermaid-integration.d.ts` — public types. Any approach that changes config shape must update this.
+- `AGENTS.md` — project constraints and conventions.
+
+## Hard rules for this codebase (weigh every approach against these)
+1. **Never serialize arbitrary function bodies to the client.** The client script is built as a string. Anything user-supplied that crosses to the browser must be plain data or a safely-extracted value (e.g. a URL). `new Function(...)`/`eval` on user input is a security defect — issue #18 exists because of exactly this pattern.
+2. **Public API is a contract.** New config options need `.d.ts` types, README + `docs/API.md` updates, and sensible defaults.
+3. **Astro 4/5/6 must all keep working** (peer dep `astro >=4`).
+4. **Backwards compatibility** — existing `iconPacks`/config usage must not break.
+
+## What to produce
+Return a concise markdown report:
+1. **Problem restatement** — the actual root cause, not the surface symptom. Read the linked issue/PR if given.
+2. **2–4 candidate approaches** — for each: how it works, what files change, security/compat implications, and effort.
+3. **Recommendation** — pick one, justify it, and call out the failure mode of the *naive* fix (what a hurried implementer would get wrong).
+4. **Test angles** — the specific cases a TDD implementer should cover (happy path, the regression that motivated the issue, edge/security cases).
+
+Be skeptical. If an approach reintroduces a pattern a past issue removed, say so explicitly. Do not write implementation code — outlines and signatures only.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,42 @@
+---
+name: code-reviewer
+description: Adversarial pre-merge review of a diff for the astro-mermaid integration. Use before merging any issue/PR. Checks correctness, security (client serialization), test coverage, docs drift, and backward compat. Returns blocking vs non-blocking findings.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You are an adversarial code reviewer for the **astro-mermaid** Astro integration. Your default stance is skeptical: assume the change is subtly wrong until the diff proves otherwise. You do not rubber-stamp.
+
+## How to review
+1. Get the diff: `git diff origin/main...HEAD` (or the range you are told). Read every changed hunk.
+2. Read the surrounding code, not just the diff — a change can be locally correct but break a caller.
+3. Run the suite: `npm test`. Report pass/fail with the actual output.
+
+## Checklist (in priority order)
+
+**Security (blocking):**
+- Does anything user-supplied get serialized into the client script string? Trace `iconPacksConfig`, the injected `mermaidScriptContent`, and any `JSON.stringify` into the page.
+- Any `new Function(...)`, `eval`, or `.toString()` on user input reaching the browser? This is the #18 class of bug — flag immediately.
+
+**Correctness (blocking):**
+- Does the change handle the case that motivated the issue? Is there a regression test that fails without the fix?
+- Null/undefined handling on optional config fields (e.g. a pack with `icons` but no `loader`/`url`, and vice versa).
+- Does the config:setup hook still run for all valid inputs (no crash on a new option shape)?
+
+**Compatibility (blocking):**
+- Backwards compat: existing `iconPacks`/config usage still works?
+- Astro 4/5/6 — anything version-specific?
+
+**Coverage & docs (non-blocking unless public API changed):**
+- New behavior has a test in `test/`.
+- Public API change reflected in `.d.ts`, `README.md`, and `docs/API.md`. Docs drift on a public option IS blocking.
+- `CHANGELOG.md` `[Unreleased]` updated; commit type matches impact (`fix`/`feat`).
+
+## Output
+Return:
+- **Verdict**: `APPROVE` / `APPROVE WITH NITS` / `REQUEST CHANGES`.
+- **Blocking findings** — each with `file:line`, what's wrong, and a concrete fix.
+- **Non-blocking nits** — brief.
+- **Test result** — pass/fail + summary.
+
+Be specific and cite `file:line`. If you find nothing wrong, say what you checked so the approval is trustworthy. Do not modify files — review only.

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: work-issue
+description: End-to-end workflow for resolving a GitHub issue in astro-mermaid — triages complexity, then runs brainstorm → TDD → implement → docs/spec → code review at the right depth. Use when the user says "work issue N", "fix issue N", "/work-issue N", or asks to resolve a GitHub issue/PR in this repo.
+---
+
+# Work an Issue
+
+Resolve a GitHub issue for **astro-mermaid** with ceremony scaled to its complexity. Two phases — triage, then execute the tier.
+
+The argument is an issue number (or PR number). If none is given, ask which issue.
+
+## Step 0 — Load context
+- `gh issue view <n>` (or `gh pr view <n>`) — read the full body and comments.
+- Read `AGENTS.md`, `astro-mermaid-integration.js`, `astro-mermaid-integration.d.ts`.
+- Create a branch: `git checkout -b fix/issue-<n>-<slug>` (use `feat/` for features). Never work on `main`.
+
+## Step 1 — Triage into a tier
+Classify the issue, then state the tier to the user before proceeding:
+
+- **Trivial** — typo, dep bump, doc-only, copy fix. → Skip to "Implement" + "Verify". No subagents.
+- **Standard** — a contained bug or feature with clear scope. → TDD → implement → docs → **one** code-reviewer subagent.
+- **Subtle** — touches client serialization/security, the public config API, or has multiple viable approaches (the #18 class). → Full pipeline including the brainstorm subagent and an adversarial review.
+
+When unsure, round **up** a tier.
+
+## Step 2 — Brainstorm (Subtle tier only)
+Spawn the **brainstorm** subagent (Agent tool, `subagent_type: "brainstorm"`) with the issue text. Wait for its ranked approaches. Pick one, tell the user which and why. Do not skip this for security/API issues — it exists to stop naive fixes (see #18).
+
+## Step 3 — TDD (Standard + Subtle)
+Write the failing test FIRST in `test/` (vitest). It must encode the regression that motivated the issue — i.e. it fails on `origin/main` and passes after the fix. Run `npm test` and confirm the new test fails for the right reason before implementing.
+
+## Step 4 — Implement
+Make the change in `astro-mermaid-integration.js` (and `.d.ts` if the public API changes). Honor the hard rules in `AGENTS.md` — especially: **never serialize user functions to the client.** Run `npm test` until green.
+
+## Step 5 — Spec & docs update
+If the public API or behavior changed, update in the same commit:
+- `astro-mermaid-integration.d.ts` (types)
+- `README.md` and `docs/API.md`
+- `CHANGELOG.md` → `[Unreleased]`
+Skip only for genuinely internal changes.
+
+## Step 6 — Verify in a demo (when user-visible)
+If the change affects rendering, add/adjust an example in a demo's content and confirm it renders (the `verify` or `run` skill, or a quick Playwright check). Refresh the stale `file:..` copy first: `cp astro-mermaid-integration.js astro-mermaid-integration.d.ts <demo>/node_modules/astro-mermaid/`.
+
+## Step 7 — Code review (Standard + Subtle)
+Spawn the **code-reviewer** subagent (`subagent_type: "code-reviewer"`) on the diff. Address every **blocking** finding (re-run review if needed). Report nits to the user.
+
+## Step 8 — Commit & push
+- Conventional Commits — `fix:` for bugs, `feat:` for features. Reference the issue (`fixes #<n>`).
+- End the commit body with the `Co-Authored-By` trailer.
+- Push the branch. Tell the user the branch is up and offer to open/update the PR (`gh pr create`).
+
+## Notes
+- Never edit `version` in `package.json` — semantic-release owns it.
+- `docs:`/`chore:`/`test:` commits do not trigger a release; a `fix:`/`feat:` must carry the user-facing change for it to ship.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,24 @@ cd starlight-demo && npm install && npm run dev
 cd astro-demo && npm install && npm run dev
 ```
 
+## Working an Issue
+
+Use the **`/work-issue <n>`** skill to resolve a GitHub issue end-to-end. It triages the issue into a tier and scales the process accordingly:
+
+- **Trivial** (typo, dep bump, doc-only): implement + verify, no subagents.
+- **Standard** (contained bug/feature): write a failing test first → implement → update docs → one **code-reviewer** subagent.
+- **Subtle** (client serialization/security, public-API shape, multiple viable approaches): add a **brainstorm** subagent up front and an adversarial review. The #18 serialization bug is the canonical example.
+
+Two specialist subagents live in `.claude/agents/`:
+- **`brainstorm`** — explores approaches and trade-offs before code is written; flags naive fixes.
+- **`code-reviewer`** — adversarial pre-merge review; security, correctness, compat, test coverage, docs drift.
+
+### Hard rules every agent must honor
+1. **Never serialize arbitrary user-supplied functions into the client script.** The client bundle is built as a string; only plain data or safely-extracted values (e.g. a `fetch()` URL) may cross to the browser. `new Function(...)`/`eval` on user input is a security defect — this is what caused #18.
+2. **Test-first** for behavior changes: a regression test in `test/` that fails on `main` and passes after the fix.
+3. **Public-API changes** must update `astro-mermaid-integration.d.ts`, `README.md`, `docs/API.md`, and `CHANGELOG.md` in the same change.
+4. **Always branch** — never commit directly to `main`.
+
 ## Netlify Deploy Previews
 
 Both demos have `netlify.toml` configs. The build command pattern is:


### PR DESCRIPTION
## What

Adds a reusable, tiered workflow for resolving GitHub issues in this repo, runnable from one entry point.

- **`/work-issue <n>` skill** (`.claude/skills/work-issue/`) — triages an issue into **trivial / standard / subtle** tiers and scales the process: brainstorm → TDD (test-first) → implement → spec/docs update → code review, at the right depth.
- **`brainstorm` subagent** (`.claude/agents/brainstorm.md`) — explores solution approaches and trade-offs before code is written; flags naive fixes (e.g. reintroducing client-side function serialization).
- **`code-reviewer` subagent** (`.claude/agents/code-reviewer.md`) — adversarial pre-merge review covering security (client serialization), correctness, backward compat, test coverage, and docs drift.
- **`AGENTS.md`** — new "Working an Issue" section documenting the tiers, the two subagents, and the hard rules every agent must honor.

## Why

Issue #18 is the motivating case: a "one-line" serialization bug whose naive fix reintroduced an `eval`-style `new Function(...)` pattern on user input. A brainstorm pass and an adversarial review each catch that class of mistake independently. This formalizes that process so it's repeatable, while keeping trivial fixes lightweight.

## Notes

- Process/tooling only — no changes to the published integration, so no release is triggered (`chore:`).
- Independent of #20 (the #18 fix) — kept on its own branch deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)