### PR TITLE
docs: fix C4 container diagram using unsupported Rel_Back_Neighbor

### DIFF
--- a/astro-demo/src/content/docs/examples/c4.md
+++ b/astro-demo/src/content/docs/examples/c4.md
@@ -65,7 +65,7 @@ C4Container
 
     Rel(spa, api, "Uses", "JSON/HTTPS")
     Rel(mobile_app, api, "Uses", "JSON/HTTPS")
-    Rel_Back_Neighbor(database, api, "Reads from and writes to", "SQL")
+    Rel(api, database, "Reads from and writes to", "SQL")
 
     Rel(api, banking_system, "Uses", "XML/HTTPS")
     Rel(api, email_system, "Sends e-mail using", "SMTP")

--- a/starlight-demo/src/content/docs/examples/c4.md
+++ b/starlight-demo/src/content/docs/examples/c4.md
@@ -65,7 +65,7 @@ C4Container
 
     Rel(spa, api, "Uses", "JSON/HTTPS")
     Rel(mobile_app, api, "Uses", "JSON/HTTPS")
-    Rel_Back_Neighbor(database, api, "Reads from and writes to", "SQL")
+    Rel(api, database, "Reads from and writes to", "SQL")
 
     Rel(api, banking_system, "Uses", "XML/HTTPS")
     Rel(api, email_system, "Sends e-mail using", "SMTP")


### PR DESCRIPTION
## Summary

The **Container Diagram** example in both demos failed at render time:

```
Error rendering diagram: Lexical error on line 29. Unrecognized text.
..., "JSON/HTTPS")    Rel_Back_Neighbor(da
----------------------^
```

Mermaid's C4 parser supports `Rel`, `BiRel`, `Rel_Back`, and the directional `Rel_U/D/L/R` variants — but **not** `Rel_Back_Neighbor`, which is a [C4-PlantUML](https://github.com/plantuml-stdlib/C4-PlantUML) keyword that mermaid never implemented.

## Fix

Replace it with the semantically equivalent, supported relationship — the API application reads from and writes to the database:

```diff
- Rel_Back_Neighbor(database, api, "Reads from and writes to", "SQL")
+ Rel(api, database, "Reads from and writes to", "SQL")
```

Applied to both `starlight-demo` and `astro-demo`.

## Verification

Validated with `mermaid.parse()` under jsdom: the corrected diagram parses cleanly, and the original `Rel_Back_Neighbor` reproduces the exact reported `Lexical error … Unrecognized text`.

Demo-only example content (not part of the published package), so committed as `docs:` to avoid triggering a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)