### PR TITLE
feat: support Astro 7 Sätteri markdown processor (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Astro 7 / Sätteri Support**: When the active markdown processor is Sätteri (`@astrojs/markdown-satteri`, the Astro 7 default), the integration registers its transform as a Sätteri mdast plugin so mermaid blocks render without forcing sites back onto `unified()`. Astro 6.4+ (`unified`) and pre-6.4 (legacy plugin arrays) continue to work unchanged — the path is chosen by detecting the processor at build time ([#71](https://github.com/joesaby/astro-mermaid/issues/71))
+
 ### Fixed
 - **Markdown Processor Deprecation**: On Astro 6.4+, the integration now registers its remark/rehype plugins via `markdown.processor` (`unified({...})`) instead of the deprecated `markdown.remarkPlugins` / `markdown.rehypePlugins` arrays, eliminating the deprecation warning. Older Astro versions transparently fall back to the legacy plugin arrays ([#62](https://github.com/joesaby/astro-mermaid/issues/62))
 - **Icon Pack Serialization**: Added `icons` property to `iconPacks` configuration to allow direct data passing, fixing serialization issues with external references ([#18](https://github.com/joesaby/astro-mermaid/issues/18))

--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ npm install @mermaid-js/layout-elk
 
 Learn more about [Mermaid layouts](https://mermaid.js.org/config/layouts.html) or [The Eclipse Layout Kernel](https://eclipse.dev/elk/).
 
+## Astro Compatibility
+
+`astro-mermaid` works across Astro 4, 5, 6, and 7 — no configuration needed. It
+detects the active markdown engine at build time and registers its transform the
+right way for each:
+
+| Astro version | Markdown engine | How mermaid hooks in |
+|---------------|-----------------|----------------------|
+| 7+ | Sätteri (`@astrojs/markdown-satteri`, the new default) | a Sätteri **mdast plugin** |
+| 6.4 – 6.x | `unified()` processor | remark + rehype plugins via `markdown.processor` |
+| < 6.4 | legacy pipeline | `markdown.remarkPlugins` / `markdown.rehypePlugins` |
+
+If you previously pinned `markdown.processor` to `unified()` purely to keep
+mermaid working on Astro 7, you can now drop that workaround and let Astro use
+its default Sätteri processor.
+
 ## Integration Order (Important!)
 
 When using with Starlight or other markdown-processing integrations, place mermaid **first**:

--- a/astro-demo/package.json
+++ b/astro-demo/package.json
@@ -10,7 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^6.0.0",
+    "astro": "^7.0.2",
     "astro-mermaid": "file:..",
     "mdast-util-to-string": "^4.0.0",
     "mermaid": "^11.0.0",

--- a/astro-demo/src/content/docs/configuration.md
+++ b/astro-demo/src/content/docs/configuration.md
@@ -120,3 +120,46 @@ export default defineConfig({
   ]
 });
 ```
+
+## Markdown Processor (Astro version support)
+
+`astro-mermaid` works on Astro 4, 5, 6, and 7 with **no extra configuration**. It
+detects which markdown engine Astro is using at build time and registers its
+transform the right way for each:
+
+| Astro version | Markdown engine | How mermaid hooks in |
+|---------------|-----------------|----------------------|
+| 7+ | Sätteri (`@astrojs/markdown-satteri`, the new default) | a Sätteri **mdast plugin** |
+| 6.4 – 6.x | `unified()` processor | remark + rehype plugins |
+| < 6.4 | legacy pipeline | `remarkPlugins` / `rehypePlugins` arrays |
+
+You normally don't set `markdown.processor` at all — Astro picks a default and
+mermaid follows it. On **Astro 7 the default is Sätteri**, the faster engine and
+the recommended choice. This standalone demo uses that default.
+
+### Choosing a processor explicitly
+
+Both processors are fully supported, and diagrams render identically on either:
+
+```js
+import { defineConfig } from 'astro/config';
+import mermaid from 'astro-mermaid';
+import { satteri } from '@astrojs/markdown-satteri';
+// import { unified } from '@astrojs/markdown-remark';
+
+export default defineConfig({
+  markdown: {
+    // Preferred on Astro 7 — the default, faster engine.
+    processor: satteri(),
+    // Legacy alternative — mermaid works here too:
+    // processor: unified(),
+  },
+  integrations: [
+    mermaid({ theme: 'forest', autoTheme: true })
+  ]
+});
+```
+
+> **Tip:** If you previously pinned `markdown.processor: unified()` purely to
+> keep mermaid working after upgrading to Astro 7, you can drop that workaround
+> and let Astro use its default Sätteri processor.

--- a/astro-mermaid-integration.js
+++ b/astro-mermaid-integration.js
@@ -82,6 +82,40 @@ function remarkMermaidPlugin(options = {}) {
 }
 
 /**
+ * Sätteri mdast plugin to transform mermaid code blocks at the markdown level.
+ *
+ * Astro 7 ships `@astrojs/markdown-satteri` as the default markdown processor,
+ * which has its own mdast/hast plugin model instead of remark/rehype. This is
+ * the Sätteri equivalent of `remarkMermaidPlugin`: it visits `code` nodes and
+ * replaces mermaid blocks with a `<pre class="mermaid">` HTML node. Fixes #71.
+ *
+ * The visitor returns a plain `{ type: 'html' }` node — NOT Sätteri's
+ * `{ rawHtml }` escape hatch. `rawHtml` applies MDX-style brace escaping that
+ * corrupts mermaid syntax (e.g. a decision node `B{Decision}` becomes
+ * `B{'{'}Decision{'}'}`), whereas an `html` node is emitted verbatim.
+ *
+ * @returns {{ name: string, code: Function }} a Sätteri mdast plugin definition
+ */
+function satteriMermaidPlugin(options = {}) {
+  return {
+    name: 'astro-mermaid',
+    code(node, context) {
+      if (node.lang !== 'mermaid') return;
+
+      if (options.logger) {
+        const file = context?.fileURL?.pathname || 'unknown file';
+        options.logger.info(`Sätteri transformed mermaid block in ${file}`);
+      }
+
+      return {
+        type: 'html',
+        value: `<pre class="mermaid">${escapeHtml(node.value)}</pre>`
+      };
+    }
+  };
+}
+
+/**
  * Escape a string for safe use inside an HTML attribute value.
  */
 function escapeAttribute(value) {
@@ -259,16 +293,20 @@ export default function astroMermaid(options = {}) {
         const rehypeEntry = [rehypeMermaidPlugin, { logger }];
         const viteConfig = { optimizeDeps: { include: viteOptimizeDepsInclude } };
 
-        // Astro 6.4+ deprecated `markdown.remarkPlugins` / `markdown.rehypePlugins`
-        // in favor of passing plugins to `unified({...})` via `markdown.processor`.
-        // On 6.4+ Astro always supplies a default unified processor, so its
-        // presence is our signal to use the new API and avoid the deprecation
-        // warning. Older Astro versions have no processor — fall back to the
-        // (still-supported there) plugin arrays. Fixes #62.
+        // Newer Astro versions expose the markdown engine on
+        // `config.markdown.processor`, and the deprecated top-level
+        // `markdown.remarkPlugins` / `markdown.rehypePlugins` arrays no longer
+        // run on it. We dispatch on the processor's `name`:
+        //   - 'unified' (Astro 6.4+): pass plugins via `unified({...})`. Fixes #62.
+        //   - 'satteri' (Astro 7+):   register an mdast plugin via `satteri({...})`. Fixes #71.
+        //   - no processor (Astro <6.4): fall back to the still-supported arrays.
+        // Branching on `name` (rather than importing both helper packages)
+        // matters because Astro 7 does not ship `@astrojs/markdown-remark`, so a
+        // blind import there would emit a misleading warning.
         const existingProcessor = config.markdown?.processor;
         let usedProcessor = false;
 
-        if (existingProcessor) {
+        if (existingProcessor?.name === 'unified') {
           try {
             const { unified, isUnifiedProcessor } = await import('@astrojs/markdown-remark');
             if (isUnifiedProcessor(existingProcessor)) {
@@ -291,6 +329,33 @@ export default function astroMermaid(options = {}) {
             // to the legacy plugin arrays below.
             logger.warn(
               `Could not configure the unified markdown processor, falling back ` +
+              `to remark/rehype plugin arrays: ${error.message}`
+            );
+          }
+        } else if (existingProcessor?.name === 'satteri') {
+          try {
+            const { satteri, isSatteriProcessor } = await import('@astrojs/markdown-satteri');
+            if (isSatteriProcessor(existingProcessor)) {
+              const existingOptions = existingProcessor.options || {};
+              updateConfig({
+                markdown: {
+                  processor: satteri({
+                    ...existingOptions,
+                    mdastPlugins: [
+                      ...(existingOptions.mdastPlugins || []),
+                      satteriMermaidPlugin({ logger })
+                    ]
+                  })
+                },
+                vite: viteConfig
+              });
+              usedProcessor = true;
+            }
+          } catch (error) {
+            // Dynamic import failed or updateConfig rejected the processor —
+            // fall through to the legacy plugin arrays below.
+            logger.warn(
+              `Could not configure the Sätteri markdown processor, falling back ` +
               `to remark/rehype plugin arrays: ${error.message}`
             );
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
+        "@astrojs/markdown-satteri": "^0.3.2",
         "@types/hast": "^3.0.4",
         "@vitest/ui": "^4.1.8",
         "astro": "^6.4.6",
@@ -23,6 +24,7 @@
         "rehype-stringify": "^10.0.1",
         "remark-mermaid": "^0.2.0",
         "remark-parse": "^11.0.0",
+        "satteri": "^0.9.2",
         "semantic-release": "^25.0.3",
         "typescript": "^5.0.0",
         "unified": "^11.0.5",
@@ -150,6 +152,19 @@
         "vfile": "^6.0.3"
       }
     },
+    "node_modules/@astrojs/markdown-satteri": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.2.tgz",
+      "integrity": "sha512-feXuUPy41gVfeM7EHT1ciUim8ozGr+YHXab9uUBc1Hk8y60DQosO8ldL+AoPXnCAoGj1OChwHfvXmmJ6XVnY9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "satteri": "^0.9.1"
+      }
+    },
     "node_modules/@astrojs/prism": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
@@ -249,6 +264,128 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@bruits/satteri-darwin-arm64": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.2.tgz",
+      "integrity": "sha512-tRpKRsiWxyh+Q5cjLwqj+baqI9htIcKqpDcftygA08bB/4nocZsneq+CVLmqT1/njG2Gq+ET12JHECz52ybiPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@bruits/satteri-darwin-x64": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.2.tgz",
+      "integrity": "sha512-oLSI0+Upq3Nd1brOdRSl044TMKgy7S6cF4sM7a9/Ms6/IADvuey+9yG3GBXxLGAzSYzR0/hh7PPSP1QBfsBKwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-arm64-gnu": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.2.tgz",
+      "integrity": "sha512-G+G6uYscRc4VUTNgZgS6SSfTHh04q/d5WiH66Jg39eftMzTAsT5cLSEHDTvDpleUT6BMNHdunx927WbddDgw7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-arm64-musl": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.2.tgz",
+      "integrity": "sha512-wRaKSHCRXwzAZwlieCiv3u8pWEE2t9FmhZ0X59YZvHCGin56YUBOTyEQqSOrRfXs6fhUb8ylprisGYJC6J8mFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-x64-gnu": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.2.tgz",
+      "integrity": "sha512-hxEq3g/kS3tm3GKc2aRYnLMFI5IjxYzcd2sCwEH2C0V+m9TTAf+7Snt/+AZZklpxDOBrI+zthJHip9xnk9uM3g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-x64-musl": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.2.tgz",
+      "integrity": "sha512-ZSu+a07Efn8sOeA1k9ZM9CO9J3sAeG37Sf2YYxi/unFGgkFe+Y8MHDQlUNtngpC8pkYIjkojkLFT6v1yiHNxOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.2.tgz",
+      "integrity": "sha512-Q/d7OIwXb5UGaiKUuPp2E6Bm41xD3sW8ts5L6l2m0Wi9uu9WKsv7CDc1ge6AVd6OC6g4nlSKWECFfPa7MkJchg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@bruits/satteri-win32-arm64-msvc": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.2.tgz",
+      "integrity": "sha512-QeaVjw+2IZeDRU7dU0KFlECTAwbL4fRUIXxZYQc4a16ejPzwizChEsKzoUBduyOJSDjyzvZxAmcdUYsSOUmR9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@bruits/satteri-win32-x64-msvc": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.2.tgz",
+      "integrity": "sha512-+hVrOLFtGgXakKO38F6afcc9/uuWvRGghPmiA6/ez5XGnWaM9VjQxqvogam5aOa7Nvl4V65P8Vpj5RsLzYeO8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
       "dev": true,
@@ -295,10 +432,33 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1257,6 +1417,25 @@
       "license": "MIT",
       "dependencies": {
         "@chevrotain/types": "~11.1.1"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -2574,6 +2753,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2826,6 +3016,16 @@
       "version": "1.0.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -10552,6 +10752,29 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/satteri": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.2.tgz",
+      "integrity": "sha512-IDJTE5SzEg9PqtdZEToQ3bjlfQ/zM+/HNaBFrwPdZbtk9IL1RWVFvzR8EMIrC0JYybJNKZS8FL45GNSAMX/6Xg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.5",
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "@types/unist": "^3.0.3"
+      },
+      "optionalDependencies": {
+        "@bruits/satteri-darwin-arm64": "0.9.2",
+        "@bruits/satteri-darwin-x64": "0.9.2",
+        "@bruits/satteri-linux-arm64-gnu": "0.9.2",
+        "@bruits/satteri-linux-arm64-musl": "0.9.2",
+        "@bruits/satteri-linux-x64-gnu": "0.9.2",
+        "@bruits/satteri-linux-x64-musl": "0.9.2",
+        "@bruits/satteri-wasm32-wasi": "0.9.2",
+        "@bruits/satteri-win32-arm64-msvc": "0.9.2",
+        "@bruits/satteri-win32-x64-msvc": "0.9.2"
+      }
     },
     "node_modules/sax": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "semantic-release": "semantic-release"
   },
   "devDependencies": {
+    "@astrojs/markdown-satteri": "^0.3.2",
     "@types/hast": "^3.0.4",
     "@vitest/ui": "^4.1.8",
     "astro": "^6.4.6",
@@ -67,6 +68,7 @@
     "rehype-stringify": "^10.0.1",
     "remark-mermaid": "^0.2.0",
     "remark-parse": "^11.0.0",
+    "satteri": "^0.9.2",
     "semantic-release": "^25.0.3",
     "typescript": "^5.0.0",
     "unified": "^11.0.5",

--- a/starlight-demo/astro.config.mjs
+++ b/starlight-demo/astro.config.mjs
@@ -1,10 +1,19 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import mermaid from "astro-mermaid";
+import { satteri } from "@astrojs/markdown-satteri";
+// import { unified } from "@astrojs/markdown-remark";
 
 export default defineConfig({
   markdown: {
-    // Ensure mermaid plugin is loaded
+    // astro-mermaid supports BOTH of Astro's markdown processors. Astro 7
+    // defaults to Sätteri, which is the faster engine and our preference, so we
+    // set it explicitly here. To use the legacy unified() pipeline instead,
+    // comment this out and uncomment the two lines below — mermaid diagrams
+    // render identically either way.
+    processor: satteri(),
+    // import { unified } from "@astrojs/markdown-remark" above, then:
+    // processor: unified(),
   },
   integrations: [
     mermaid({

--- a/starlight-demo/package.json
+++ b/starlight-demo/package.json
@@ -10,9 +10,10 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.38.0",
+    "@astrojs/markdown-satteri": "^0.3.2",
+    "@astrojs/starlight": "^0.41.0",
     "@mermaid-js/layout-elk": "^0.2.0",
-    "astro": "^6.0.0",
+    "astro": "^7.0.2",
     "astro-mermaid": "file:..",
     "mdast-util-to-string": "^4.0.0",
     "mermaid": "^11.0.0",

--- a/starlight-demo/src/content/docs/configuration.md
+++ b/starlight-demo/src/content/docs/configuration.md
@@ -120,3 +120,49 @@ export default defineConfig({
   ]
 });
 ```
+
+## Markdown Processor (Astro version support)
+
+`astro-mermaid` works on Astro 4, 5, 6, and 7 with **no extra configuration**. It
+detects which markdown engine Astro is using at build time and registers its
+transform the right way for each:
+
+| Astro version | Markdown engine | How mermaid hooks in |
+|---------------|-----------------|----------------------|
+| 7+ | Sätteri (`@astrojs/markdown-satteri`, the new default) | a Sätteri **mdast plugin** |
+| 6.4 – 6.x | `unified()` processor | remark + rehype plugins |
+| < 6.4 | legacy pipeline | `remarkPlugins` / `rehypePlugins` arrays |
+
+You normally don't set `markdown.processor` at all — Astro picks a default and
+mermaid follows it. On **Astro 7 the default is Sätteri**, which is the faster
+engine and the recommended choice.
+
+### Choosing a processor explicitly
+
+Both processors are fully supported, and diagrams render identically on either.
+This demo sets Sätteri explicitly to make the preference clear:
+
+```js
+import { defineConfig } from 'astro/config';
+import mermaid from 'astro-mermaid';
+import { satteri } from '@astrojs/markdown-satteri';
+// import { unified } from '@astrojs/markdown-remark';
+
+export default defineConfig({
+  markdown: {
+    // Preferred on Astro 7 — the default, faster engine.
+    processor: satteri(),
+    // Legacy alternative — mermaid works here too:
+    // processor: unified(),
+  },
+  integrations: [
+    mermaid({ theme: 'forest', autoTheme: true })
+  ]
+});
+```
+
+:::tip
+If you previously pinned `markdown.processor: unified()` purely to keep mermaid
+working after upgrading to Astro 7, you can drop that workaround and let Astro
+use its default Sätteri processor.
+:::

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { unified } from '@astrojs/markdown-remark';
+import { satteri } from '@astrojs/markdown-satteri';
 import astroMermaid from '../astro-mermaid-integration.js';
 
 describe('astroMermaid Integration', () => {
@@ -219,6 +220,110 @@ describe('astroMermaid Integration', () => {
       expect(updateCall.markdown.remarkPlugins).toBeDefined();
       expect(updateCall.markdown.rehypePlugins).toBeDefined();
       expect(updateCall.markdown.processor).toBeUndefined();
+    });
+  });
+
+  describe('markdown processor API (Astro 7 / Sätteri)', () => {
+    // Astro 7 ships @astrojs/markdown-satteri as the default markdown processor.
+    // It has its own mdast/hast plugin model instead of remark/rehype, so our
+    // remark transform must be registered as a Sätteri mdast plugin (issue #71).
+
+    it('should route the transform through the Sätteri processor when one is present', async () => {
+      const integration = astroMermaid();
+
+      const mockConfig = {
+        markdown: {
+          // Simulate Astro 7 default: a real Sätteri processor instance
+          processor: satteri()
+        },
+        root: new URL('file:///test/')
+      };
+
+      const updateConfigMock = vi.fn();
+
+      await integration.hooks['astro:config:setup']({
+        config: mockConfig,
+        updateConfig: updateConfigMock,
+        addWatchFile: vi.fn(),
+        injectScript: vi.fn(),
+        logger: { info: vi.fn(), warn: vi.fn() },
+        command: 'build'
+      });
+
+      expect(updateConfigMock).toHaveBeenCalled();
+      const updateCall = updateConfigMock.mock.calls[0][0];
+
+      // Must set a Sätteri processor, NOT the deprecated remark/rehype arrays
+      expect(updateCall.markdown.processor).toBeDefined();
+      expect(updateCall.markdown.processor.name).toBe('satteri');
+      expect(updateCall.markdown.remarkPlugins).toBeUndefined();
+      expect(updateCall.markdown.rehypePlugins).toBeUndefined();
+
+      // The new processor must carry our mdast plugin
+      const opts = updateCall.markdown.processor.options;
+      const ours = opts.mdastPlugins.find(p => p?.name === 'astro-mermaid');
+      expect(ours).toBeDefined();
+      expect(typeof ours.code).toBe('function');
+    });
+
+    it('should preserve mdast/hast plugins already on the existing Sätteri processor', async () => {
+      const existingMdast = { name: 'existing-mdast', paragraph() {} };
+      const existingHast = { name: 'existing-hast', element() {} };
+
+      const integration = astroMermaid();
+
+      const mockConfig = {
+        markdown: {
+          processor: satteri({
+            mdastPlugins: [existingMdast],
+            hastPlugins: [existingHast]
+          })
+        },
+        root: new URL('file:///test/')
+      };
+
+      const updateConfigMock = vi.fn();
+
+      await integration.hooks['astro:config:setup']({
+        config: mockConfig,
+        updateConfig: updateConfigMock,
+        addWatchFile: vi.fn(),
+        injectScript: vi.fn(),
+        logger: { info: vi.fn(), warn: vi.fn() },
+        command: 'build'
+      });
+
+      const opts = updateConfigMock.mock.calls[0][0].markdown.processor.options;
+      // Existing user plugins are kept, ours is added on top
+      expect(opts.mdastPlugins).toContain(existingMdast);
+      expect(opts.mdastPlugins.length).toBe(2);
+      expect(opts.hastPlugins).toContain(existingHast);
+      expect(opts.hastPlugins.length).toBe(1);
+    });
+
+    it('should not warn about the unified processor when the processor is Sätteri', async () => {
+      const integration = astroMermaid();
+
+      const mockConfig = {
+        markdown: { processor: satteri() },
+        root: new URL('file:///test/')
+      };
+
+      const warnMock = vi.fn();
+
+      await integration.hooks['astro:config:setup']({
+        config: mockConfig,
+        updateConfig: vi.fn(),
+        addWatchFile: vi.fn(),
+        injectScript: vi.fn(),
+        logger: { info: vi.fn(), warn: warnMock },
+        command: 'build'
+      });
+
+      // Astro 7 sites do not ship @astrojs/markdown-remark; we must not attempt
+      // to import it (and emit a misleading warning) when Sätteri is active.
+      const warned = warnMock.mock.calls.map(c => String(c[0])).join('\n');
+      expect(warned).not.toMatch(/unified/i);
     });
   });
 

--- a/test/satteri-plugin.test.js
+++ b/test/satteri-plugin.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { markdownToHtml } from 'satteri';
+import { satteri } from '@astrojs/markdown-satteri';
+import astroMermaid from '../astro-mermaid-integration.js';
+
+// End-to-end behaviour of the Sätteri mdast plugin (Astro 7). Unlike the
+// integration routing tests, these render real markdown through Sätteri's
+// native processor so we catch regressions in the *output* HTML — most
+// importantly that mermaid's `{...}` decision syntax survives untouched.
+
+/**
+ * Run the integration's config:setup hook with a Sätteri processor and return
+ * the mdast plugin it registers, so we can render markdown through it.
+ */
+async function getSatteriMermaidPlugin() {
+  const integration = astroMermaid();
+  const updateConfigMock = vi.fn();
+
+  await integration.hooks['astro:config:setup']({
+    config: { markdown: { processor: satteri() }, root: new URL('file:///test/') },
+    updateConfig: updateConfigMock,
+    addWatchFile: vi.fn(),
+    injectScript: vi.fn(),
+    logger: { info: vi.fn(), warn: vi.fn() },
+    command: 'build'
+  });
+
+  const opts = updateConfigMock.mock.calls[0][0].markdown.processor.options;
+  return opts.mdastPlugins.find(p => p?.name === 'astro-mermaid');
+}
+
+describe('Sätteri mermaid plugin (end-to-end render)', () => {
+  it('transforms mermaid code blocks into <pre class="mermaid">', async () => {
+    const plugin = await getSatteriMermaidPlugin();
+    const md = ['```mermaid', 'graph TD', '  A[Start] --> B[End]', '```', ''].join('\n');
+
+    const { html } = await markdownToHtml(md, { mdastPlugins: [plugin] });
+
+    expect(html).toContain('<pre class="mermaid">');
+    expect(html).toContain('A[Start]');
+    // Must NOT be left as a highlighted code block
+    expect(html).not.toContain('language-mermaid');
+  });
+
+  it('preserves mermaid curly-brace syntax (decision nodes) verbatim', async () => {
+    // Regression for #71: returning Sätteri's `{ rawHtml }` escape hatch applies
+    // MDX-style brace escaping, turning `B{Decision}` into `B{'{'}Decision{'}'}`
+    // and corrupting the diagram. We must emit a plain `html` mdast node instead.
+    const plugin = await getSatteriMermaidPlugin();
+    const md = ['```mermaid', 'graph TD', '  B{Decision}', '```', ''].join('\n');
+
+    const { html } = await markdownToHtml(md, { mdastPlugins: [plugin] });
+
+    expect(html).toContain('B{Decision}');
+    expect(html).not.toContain("{'{'}");
+  });
+
+  it('escapes HTML in diagram content but leaves non-mermaid code blocks alone', async () => {
+    const plugin = await getSatteriMermaidPlugin();
+    const md = [
+      '```mermaid',
+      'graph TD',
+      '  A["Has <br/> break"]',
+      '```',
+      '',
+      '```js',
+      'const x = 1;',
+      '```',
+      ''
+    ].join('\n');
+
+    const { html } = await markdownToHtml(md, { mdastPlugins: [plugin] });
+
+    // HTML inside the diagram is escaped to text, not rendered as a tag
+    expect(html).toContain('&lt;br/&gt;');
+    // The JS block is still a normal (highlighted) code block
+    expect(html).toContain('language-js');
+    expect(html).toContain('const x');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #71. Adds support for Astro 7's new default markdown processor **Sätteri** (`@astrojs/markdown-satteri`) so `mermaid` blocks render without forcing sites back onto `unified()`.

This is **additive** — Astro 4/5/6 keep working unchanged. The integration detects the active markdown engine at `astro:config:setup` by its `name` and dispatches three ways:

| Astro | Markdown engine | How mermaid hooks in |
|-------|-----------------|----------------------|
| 7+ | Sätteri (default) | a Sätteri **mdast plugin** *(new)* |
| 6.4–6.x | `unified()` | remark + rehype plugins (unchanged) |
| <6.4 | legacy | `remarkPlugins`/`rehypePlugins` arrays (unchanged) |

Detection keys on `processor.name` rather than a blind import, because `astro@7` does **not** ship `@astrojs/markdown-remark` — importing it on an Astro 7 site would emit a misleading warning.

## Key correctness detail

The Sätteri mdast visitor returns a plain `{ type: 'html' }` node, **not** Sätteri's `{ rawHtml }` escape hatch. `rawHtml` applies MDX-style brace escaping that corrupts mermaid decision-node syntax:

```
B{Decision}  →  B{'{'}Decision{'}'}   ❌ (rawHtml)
B{Decision}  →  B{Decision}           ✅ (html node)
```

A regression test guards this exact case.

## Acceptance criteria

- [x] Mermaid blocks render when `markdown.processor` is the Astro 7 default (`satteri()`)
- [x] Existing unified-based setups continue to work unchanged
- [x] No reliance on deprecated top-level `markdown.remarkPlugins` when Sätteri is active
- [x] Documented in README + both demo docs with an Astro 7 migration note

## Testing

- 34/34 unit tests pass (5 new), including an **end-to-end render through the real Sätteri native processor** asserting brace preservation.
- **astro-demo** (standalone) upgraded to Astro 7 → uses Sätteri → 17 pages render, braces intact, zero corruption.
- **starlight-demo** upgraded to Astro 7 + Starlight 0.41 → also uses Sätteri (Starlight mutates `processor.options` in place and coexists with our plugin) → 16 pages render. Confirmed via build log `[astro-mermaid] Sätteri transformed mermaid block`.
- Verified the `unified()` alternative still renders identically on Astro 7 (toggled, built, reverted).

## Notes

- `satteri` / `@astrojs/markdown-satteri` are **devDeps only** (for tests), matching the existing pattern for `@astrojs/markdown-remark` — neither is a peer dep; both arrive transitively with the user's Astro version.
- The starlight demo's `astro.config.mjs` now sets `processor: satteri()` explicitly (with a commented `unified()` alternative) to demonstrate both are supported, preferring Sätteri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)